### PR TITLE
H1 : Implementing getreadcount system call

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,7 @@ UPROGS=\
 	$U/_grind\
 	$U/_wc\
 	$U/_zombie\
+	$U/_h1_readcount\
 
 fs.img: mkfs/mkfs README $(UPROGS)
 	mkfs/mkfs fs.img README $(UPROGS)

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -101,6 +101,7 @@ extern uint64 sys_unlink(void);
 extern uint64 sys_link(void);
 extern uint64 sys_mkdir(void);
 extern uint64 sys_close(void);
+extern uint64 sys_getreadcount(void);
 
 // An array mapping syscall numbers from syscall.h
 // to the function that handles the system call.
@@ -126,6 +127,7 @@ static uint64 (*syscalls[])(void) = {
 [SYS_link]    sys_link,
 [SYS_mkdir]   sys_mkdir,
 [SYS_close]   sys_close,
+[SYS_getreadcount] sys_getreadcount,
 };
 
 void

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -20,3 +20,4 @@
 #define SYS_link   19
 #define SYS_mkdir  20
 #define SYS_close  21
+#define SYS_getreadcount 22

--- a/kernel/sysfile.c
+++ b/kernel/sysfile.c
@@ -16,7 +16,7 @@
 #include "file.h"
 #include "fcntl.h"
 
-static int readcount = 0;
+static _Atomic uint64 readcount = 0;
 
 // Fetch the nth word-sized system call argument as a file descriptor
 // and return both the descriptor and the corresponding struct file.

--- a/kernel/sysfile.c
+++ b/kernel/sysfile.c
@@ -16,6 +16,8 @@
 #include "file.h"
 #include "fcntl.h"
 
+static int readcount = 0;
+
 // Fetch the nth word-sized system call argument as a file descriptor
 // and return both the descriptor and the corresponding struct file.
 static int
@@ -71,6 +73,8 @@ sys_read(void)
   struct file *f;
   int n;
   uint64 p;
+
+  readcount += 1;
 
   argaddr(1, &p);
   argint(2, &n);
@@ -502,4 +506,10 @@ sys_pipe(void)
     return -1;
   }
   return 0;
+}
+
+uint64
+sys_getreadcount(void)
+{
+  return readcount;
 }

--- a/user/h1_readcount.c
+++ b/user/h1_readcount.c
@@ -1,0 +1,44 @@
+#include "kernel/types.h"
+#include "kernel/fcntl.h"
+#include "kernel/stat.h"
+#include "user/user.h"
+
+int
+main(int argc, char *argv[])
+{
+  int nproc = 4;    
+  int loops = 10000; 
+  if(argc == 3){
+    nproc = atoi(argv[1]);
+    loops = atoi(argv[2]);
+  }
+
+  uint64 before = getreadcount();
+
+  for(int i = 0; i < nproc; i++){
+    if(fork() == 0){
+      char dummy;
+      for(int j = 0; j < loops; j++){
+        read(0, &dummy, 0); 
+      }
+      exit(0);
+    }
+  }
+
+  for(int i = 0; i < nproc; i++)
+    wait(0);
+
+  uint64 after = getreadcount();
+  uint64 delta = after - before;
+  uint64 expected = (uint64)nproc * (uint64)loops;
+
+  printf("before=%lu after=%lu delta=%lu expected=%lu\n",
+         before, after, delta, expected);
+
+  if(delta == expected)
+    printf("PASS: atomic increments\n");
+  else
+    printf("FAIL: lost increments\n");
+
+  exit(0);
+}

--- a/user/user.h
+++ b/user/user.h
@@ -22,6 +22,7 @@ int getpid(void);
 char* sbrk(int);
 int sleep(int);
 int uptime(void);
+uint64 getreadcount(void);
 
 // ulib.c
 int stat(const char*, struct stat*);

--- a/user/usys.pl
+++ b/user/usys.pl
@@ -36,3 +36,4 @@ entry("getpid");
 entry("sbrk");
 entry("sleep");
 entry("uptime");
+entry("getreadcount");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a system call to retrieve the total number of read operations performed.
  * Added a user-space utility (h1_readcount) that spawns multiple processes to perform reads, then reports before/after counts, delta, expected value, and PASS/FAIL.
  * Included the new utility in the default filesystem image, making it available after build.
  * Exposed a user-level API to access the read-count, enabling apps and tests to query it directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->